### PR TITLE
fix: Update rev 239 and update widget ids for banking.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 // Project version is set via the VERSION environment
 // variable in the Github Actions workflow and should not be changed here.
 def projectVersion = System.getenv("VERSION") ?: '1.0.0'
-def runeLiteVersion = '1.12.29.1' // latest.release
+def runeLiteVersion = '1.12.30' // latest.release
 
 version = projectVersion
 project.version = projectVersion

--- a/docs/kraken-api/com.kraken.api.service.util/-reflection-service/index.md
+++ b/docs/kraken-api/com.kraken.api.service.util/-reflection-service/index.md
@@ -7,7 +7,7 @@ open class [ReflectionService](index.md)
 
 Service for handling reflection operations, including field access and method invocation. 
 
- This service maintains a cache of reflected fields and methods to improve performance for repeated accesses. It supports accessing obfuscated members via the class and member names mapped in `hooks.json`.
+ This service maintains a cache of reflected fields and methods to improve performance for repeated accesses. It supports accessing obfuscated members via the class and member names mapped in `hooks-238.json`.
 
 ## Constructors
 

--- a/src/main/java/com/kraken/api/service/bank/BankService.java
+++ b/src/main/java/com/kraken/api/service/bank/BankService.java
@@ -35,7 +35,7 @@ import static net.runelite.api.gameval.VarbitID.BANK_WITHDRAWNOTES;
 @Slf4j
 @Singleton
 public class BankService {
-    private static final int WITHDRAW_ITEM_NOT_MODE_WIDGET = 786451;
+    private static final int WITHDRAW_ITEM_NOTE_MODE_WIDGET = 786457;
 
     @Inject
     private Provider<Context> ctxProvider;
@@ -163,7 +163,7 @@ public class BankService {
 
         if (currentMode == targetMode) return true;
 
-        Widget toggleWidget = client.getWidget(WITHDRAW_ITEM_NOT_MODE_WIDGET);
+        Widget toggleWidget = client.getWidget(WITHDRAW_ITEM_NOTE_MODE_WIDGET);
 
         if (toggleWidget != null) {
             String action = noted ? "Enable <col=ff9040>Notes" : "Disable <col=ff9040>Notes";
@@ -223,7 +223,7 @@ public class BankService {
     }
 
     /**
-     * Deposit all items in the players inventory into the bank.
+     * Deposit all items in the player's inventory into the bank.
      * @return True if the deposit was successful and false otherwise
      */
     public boolean depositAll() {
@@ -231,10 +231,10 @@ public class BankService {
             if(ctxProvider.get().inventory().isEmpty()) return true;
             if (!isOpen()) return false;
 
-            Widget widget = client.getWidget(786473);
+            Widget widget = client.getWidget(786479);
             if (widget == null) return false;
 
-            ctxProvider.get().widgets().withId(786473).first().interact("Deposit inventory");
+            ctxProvider.get().widgets().withId(786479).first().interact("Deposit inventory");
             return true;
         });
     }
@@ -247,10 +247,10 @@ public class BankService {
         return ctxProvider.get().runOnClientThread(() -> {
             if (!isOpen()) return false;
 
-            Widget widget = client.getWidget(786475);
+            Widget widget = client.getWidget(786481);
             if (widget == null) return false;
 
-            ctxProvider.get().widgets().withId(786475).first().interact("Deposit worn items");
+            ctxProvider.get().widgets().withId(786481).first().interact("Deposit worn items");
             return true;
         });
     }
@@ -264,10 +264,10 @@ public class BankService {
         return ctxProvider.get().runOnClientThread(() -> {
             if (!isOpen()) return false;
 
-            Widget widget = client.getWidget(786471);
+            Widget widget = client.getWidget(786477);
             if (widget == null) return false;
 
-            ctxProvider.get().widgets().withId(786471).first().interact("Empty containers");
+            ctxProvider.get().widgets().withId(786477).first().interact("Empty containers");
             return true;
         });
     }

--- a/src/main/java/com/kraken/api/service/util/ReflectionService.java
+++ b/src/main/java/com/kraken/api/service/util/ReflectionService.java
@@ -97,7 +97,7 @@ public class ReflectionService {
         }
     }
 
-    private Field getField(String className, String fieldName) throws Exception {
+    private Field getField(String className, String fieldName) {
         FieldLookup lookup = new FieldLookup(className, fieldName);
         return fieldCache.computeIfAbsent(lookup, key -> {
             try {

--- a/src/main/resources/hooks.json
+++ b/src/main/resources/hooks.json
@@ -37,6 +37,8 @@
     "accountIdClassName": "lo",
     "accountCheckFieldName": "da",
     "accountCheckClassName": "client",
+    "displayNameFieldName": "cl",
+    "displayNameClassName": "bx",
     "jagexValueFieldName": "af",
     "jagexValueClassName": "zd",
     "legacyValueFieldName": "ag",

--- a/src/main/resources/hooks.json
+++ b/src/main/resources/hooks.json
@@ -1,113 +1,113 @@
 {
   "reflectionHooks": {
-    "isaacCipherFieldName": "av",
-    "addNodeMethodName": "az",
+    "isaacCipherFieldName": "aa",
+    "addNodeMethodName": "ae",
     "addNodeClassName": "client",
-    "addNodeGarbageValue": -2039989469,
-    "clientPacketClassName": "jb",
-    "packetWriterClassName": "df",
-    "packetWriterFieldName": "aq",
-    "classContainingPacketBufferNodeName": "gi",
-    "packetBufferNodeFactoryMethodName": "ak",
-    "bufferClassName": "xj",
-    "extendedBufferClassName": "xi",
-    "offsetMultiplier": 228932457,
-    "indexMultiplier": -661977895,
-    "bufferOffsetField": "au",
-    "bufferArrayField": "al",
-    "mouseHandlerLastPressedClass": "tj",
-    "mouseHandlerLastPressedField": "af",
-    "mouseHandlerMultiplier": 3767455460529623151,
+    "addNodeGarbageValue": 2034800314,
+    "clientPacketClassName": "jf",
+    "packetWriterClassName": "dw",
+    "packetWriterFieldName": "ad",
+    "classContainingPacketBufferNodeName": "xt",
+    "packetBufferNodeFactoryMethodName": "ag",
+    "bufferClassName": "xv",
+    "extendedBufferClassName": "xm",
+    "offsetMultiplier": -1278253407,
+    "indexMultiplier": 769523041,
+    "bufferOffsetField": "ab",
+    "bufferArrayField": "ak",
+    "mouseHandlerLastPressedClass": "sw",
+    "mouseHandlerLastPressedField": "av",
+    "mouseHandlerMultiplier": 4865206394403847849,
     "clientMillisField": "gx",
-    "clientMillisMultiplier": -6682804461438542089,
-    "packetBufferNodeClassName": "jm",
-    "packetBufferFieldName": "ay",
-    "packetBufferNodeGarbageValue": 0,
-    "doActionClassName": "qd",
-    "doActionMethodName": "fa",
-    "doActionGarbageValue": 910500823
+    "clientMillisMultiplier": 5323891611902821573,
+    "packetBufferNodeClassName": "jr",
+    "packetBufferFieldName": "al",
+    "packetBufferNodeGarbageValue": -2111588182,
+    "doActionClassName": "ek",
+    "doActionMethodName": "fu",
+    "doActionGarbageValue": -35274227
+  },
+  "loginHooks": {
+    "loginIndexGarbageValue": 2112989209,
+    "loginIndexMethodName": "bo",
+    "loginIndexClassName": "pu",
+    "sessionFieldName": "ln",
+    "sessionClassName": "et",
+    "accountIdFieldName": "lx",
+    "accountIdClassName": "lo",
+    "accountCheckFieldName": "da",
+    "accountCheckClassName": "client",
+    "jagexValueFieldName": "af",
+    "jagexValueClassName": "zd",
+    "legacyValueFieldName": "ag",
+    "legacyValueClassName": "zd"
   },
   "securityHooks": {
     "mouseHookDllClassName": "client",
-    "mouseHookDllMethodName": "ik",
+    "mouseHookDllMethodName": "ip",
+    "clientLogFieldName": "cn",
     "callStackClassName": "client",
-    "callStackMethodName": "yq",
-    "cleanCallStackValue": "client4122yq\nclient19537qj\nnrc.RuneLite297start\nnrc.RuneLite274main\nnrl.ReflectionLa+64lambda$launc+\njl.ThreadUnknown +",
-    "clientLogFieldName": "us",
-    "platformInfoClassName": "vu",
-    "platformInfoMethodName": "ak",
-    "agentField": "cw",
-    "callStackField": "cg"
-  },
-  "loginHooks": {
-    "loginIndexGarbageValue": -88,
-    "loginIndexMethodName": "ac",
-    "loginIndexClassName": "jz",
-    "sessionFieldName": "lp",
-    "sessionClassName": "ay",
-    "accountIdFieldName": "ll",
-    "accountIdClassName": "cq",
-    "displayNameFieldName": "ct",
-    "displayNameClassName": "bn",
-    "accountCheckFieldName": "dm",
-    "accountCheckClassName": "client",
-    "jagexValueFieldName": "ag",
-    "jagexValueClassName": "aao",
-    "legacyValueFieldName": "ak",
-    "legacyValueClassName": "aao"
+    "callStackMethodName": "jf",
+    "cleanCallStackValue": "client42062jf\nclient27145ml\nnrc.RuneLite297start\nnrc.RuneLite274main\nnrl.ReflectionLa+64lambda$launc+\njl.ThreadUnknown +",
+    "platformInfoClassName": "vs",
+    "platformInfoMethodName": "gz",
+    "agentField": "cs",
+    "callStackField": "cf"
   },
   "packets": {
     "EVENT_MOUSE_CLICK": {
       "packetName": "EVENT_MOUSE_CLICK",
-      "obfuscatedName": "ds",
+      "obfuscatedName": "bb",
       "writes": [
         {
-          "param": "mouseY",
-          "methodName": "ed",
-          "operations": [
-            {
-              "type": "RIGHT_SHIFT",
-              "operand": 8
-            },
-            {
-              "type": "ADD",
-              "operand": 128
-            }
-          ]
-        },
-        {
           "param": "mouseX",
-          "methodName": "ko",
+          "methodName": "ev",
           "operations": [
-            {
-              "type": "ADD",
-              "operand": 128
-            },
             {
               "type": "RIGHT_SHIFT",
               "operand": 8
-            }
-          ]
-        },
-        {
-          "param": "0",
-          "methodName": "dq",
-          "operations": [
+            },
             {
-              "type": "RAW"
+              "type": "ADD",
+              "operand": 128
             }
           ]
         },
         {
           "param": "mouseInfo",
-          "methodName": "bw",
+          "methodName": "ey",
+          "operations": [
+            {
+              "type": "ADD",
+              "operand": 128
+            },
+            {
+              "type": "RIGHT_SHIFT",
+              "operand": 8
+            }
+          ]
+        },
+        {
+          "param": "mouseY",
+          "methodName": "ev",
           "operations": [
             {
               "type": "RIGHT_SHIFT",
               "operand": 8
             },
             {
-              "type": "RAW"
+              "type": "ADD",
+              "operand": 128
+            }
+          ]
+        },
+        {
+          "param": "0",
+          "methodName": "dz",
+          "operations": [
+            {
+              "type": "SUBTRACT",
+              "operand": 128
             }
           ]
         }
@@ -116,50 +116,50 @@
     },
     "MOVE_GAMECLICK": {
       "packetName": "MOVE_GAMECLICK",
-      "obfuscatedName": "eo",
+      "obfuscatedName": "ea",
       "writes": [
         {
           "param": "5",
-          "methodName": "dq",
+          "methodName": "bw",
           "operations": [
             {
               "type": "RAW"
-            }
-          ]
-        },
-        {
-          "param": "worldPointY",
-          "methodName": "eb",
-          "operations": [
-            {
-              "type": "RAW"
-            },
-            {
-              "type": "RIGHT_SHIFT",
-              "operand": 8
             }
           ]
         },
         {
           "param": "worldPointX",
-          "methodName": "bw",
+          "methodName": "el",
           "operations": [
+            {
+              "type": "RAW"
+            },
             {
               "type": "RIGHT_SHIFT",
               "operand": 8
-            },
+            }
+          ]
+        },
+        {
+          "param": "worldPointY",
+          "methodName": "el",
+          "operations": [
             {
               "type": "RAW"
+            },
+            {
+              "type": "RIGHT_SHIFT",
+              "operand": 8
             }
           ]
         },
         {
           "param": "ctrlDown",
-          "methodName": "di",
+          "methodName": "dz",
           "operations": [
             {
               "type": "SUBTRACT",
-              "operand": 0
+              "operand": 128
             }
           ]
         }
@@ -168,11 +168,11 @@
     },
     "RESUME_COUNTDIALOG": {
       "packetName": "RESUME_COUNTDIALOG",
-      "obfuscatedName": "do",
+      "obfuscatedName": "cd",
       "writes": [
         {
           "param": "var0",
-          "methodName": "az",
+          "methodName": "cg",
           "operations": [
             {
               "type": "RIGHT_SHIFT",
@@ -196,11 +196,11 @@
     },
     "RESUME_STRINGDIALOG": {
       "packetName": "RESUME_STRINGDIALOG",
-      "obfuscatedName": "cd",
+      "obfuscatedName": "cq",
       "writes": [
         {
           "param": "length",
-          "methodName": "dq",
+          "methodName": "bw",
           "operations": [
             {
               "type": "RAW"
@@ -209,7 +209,7 @@
         },
         {
           "param": "string",
-          "methodName": "cc",
+          "methodName": "co",
           "operations": [
             {
               "type": "STRING_CP1252_NULL_TERMINATED"
@@ -221,11 +221,11 @@
     },
     "RESUME_OBJDIALOG": {
       "packetName": "RESUME_OBJDIALOG",
-      "obfuscatedName": "ex",
+      "obfuscatedName": "bs",
       "writes": [
         {
           "param": "var0",
-          "methodName": "bw",
+          "methodName": "bd",
           "operations": [
             {
               "type": "RIGHT_SHIFT",


### PR DESCRIPTION
Updates to rev 239 RuneLite v1.12.30. This fixes some widget Ids which changed this rev for bank all and bank all equipment.